### PR TITLE
Updates for ArmPL variant builds

### DIFF
--- a/recipe/aarch_site.cfg
+++ b/recipe/aarch_site.cfg
@@ -1,6 +1,0 @@
-[openblas]
-libraries = armpl_lp64
-library_dirs = $PREFIX/lib
-include_dirs = $PREFIX/include
-runtime_library_dirs = $PREFIX/lib
-

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,12 +16,20 @@ else
     export LDFLAGS="$LDFLAGS -shared"
 fi
 
-case $( uname -m ) in
+#case $( uname -m ) in
 # todo: update once ArmPL is ready.
 # We should look to include copy aarch_site.cfg in the ArmPL package, similar
 # to how OpenBLAS and MKL devels work. 
 # aarch64) cp $PREFIX/aarch_site.cfg site.cfg;;
-*)       cp $PREFIX/site.cfg site.cfg;;
-esac
+#*)       cp $PREFIX/site.cfg site.cfg;;
+#esac
+
+# To build the different BLAS variants, the site.cfg file is provided
+# by the BLAS packages (mkl-devel, openblas-devel, or armpl). See:
+#   intel_repack-feedstock/recipe/install-devel.sh
+#   openblas-feedstock/recipe/build.sh
+#   armpl-feedstock/recipe/repack_armpl.sh
+cp $PREFIX/site.cfg site.cfg
+
 
 $PYTHON -m pip install . -vv

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -49,20 +49,23 @@ requirements:
     - cython
     - pybind11
     # this setting is actually an issue of the numpy version!!
-    - numpy-devel  {{ numpy }}  # [not (osx and arm64)]
-    - numpy {{ numpy }}         # [osx and arm64]
+    - numpy-devel {{ numpy }}  # [not ((osx and arm64) or (linux and aarch64))]
+    - numpy {{ numpy }}        # [(osx and arm64) or ((linux and aarch64) and (blas_impl == 'openblas'))]
+    - numpy >=1.21             # [(linux and aarch64) and (blas_impl == 'armpl')]
     - pip
     - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
     # pin intel-openmp to the same version as mkl, without this build may fail with
     # Intel MKL FATAL ERROR: Cannot load libmkl_intel_thread.dylib.
     # It may be needed to make this pinning explicit in the mkl package
-    - intel-openmp {{ mkl }}  # [blas_impl == 'mkl']
+    - intel-openmp {{ mkl }}         # [blas_impl == 'mkl']
     - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
+    - armpl {{ armpl }}              # [blas_impl == 'armpl']
     - pythran
     - msinttypes   # [win and vc<14]
   run:
     - python
     - {{ pin_compatible('numpy') }}
+    - armpl {{ armpl }}              # [blas_impl == 'armpl']
 
 test:
   requires:


### PR DESCRIPTION
This PR includes several updates to build `scipy` with ArmPL:

- Removes `aarch_site.cfg` and the code in `build.sh` that copied it into `$PREFIX`. The `site.cfg` should actually be provided by the BLAS package (in this case, `armpl`). Appropriate changes for that have been made in `armpl-feedstock`.
- Add `armpl` as a host dependency with a selector for `blas_impl == armpl`.

I have validated these updates by building `armpl` variants of `scipy` - see here:
https://anaconda.org/aarch64-staging/scipy/files?channel=armpl_build_20211014