### PR TITLE
update to v1.9.3

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -82,6 +82,9 @@ requirements:
 # skip a test that fails with MKL + AVX512 (non-AVX512 passes) (See: https://github.com/scipy/scipy/issues/15533)
 {% set tests_to_skip = tests_to_skip + " or test_x0_equals_Mb[bicgstab]" %} # [blas_impl == 'mkl']
 
+# mark one linalg.solve_discrete_are as knownfail https://github.com/scipy/scipy/issues/16926
+{% set tests_to_skip = tests_to_skip + " or test_solve_discrete_are"  %} # [blas_impl == 'openblas']
+
 # skip failing s390x tests
 {% set tests_to_skip = tests_to_skip + " or test_jacobi_int" %} # [s390x] timeout after 1800s
 
@@ -150,9 +153,6 @@ test:
 
     # show SIMD features (some failures occur depending on presence/absence of e.g. AVX512)
     - python -c "import numpy; numpy.show_config()"
-
-    # mark one linalg.solve_discrete_are as knownfail https://github.com/scipy/scipy/issues/16926
-    {% set tests_to_skip = tests_to_skip + " or test_solve_discrete_are"  %} # [blas_impl == 'openblas']
 
     # the tests ppc64le and aarch64 are currently run through emulation in QEMU;
     # since this takes much longer, do not run the most heavy-weight tests, i.e. use

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -151,6 +151,9 @@ test:
     # show SIMD features (some failures occur depending on presence/absence of e.g. AVX512)
     - python -c "import numpy; numpy.show_config()"
 
+    # mark one linalg.solve_discrete_are as knownfail https://github.com/scipy/scipy/issues/16926
+    {% set tests_to_skip = tests_to_skip + " or test_solve_discrete_are"  %} # [blas_impl == 'openblas']
+
     # the tests ppc64le and aarch64 are currently run through emulation in QEMU;
     # since this takes much longer, do not run the most heavy-weight tests, i.e. use
     # label='fast'; same for PyPy due to huge runtime; otherwise set label='full'

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.1" %}
+{% set version = "1.9.3" %}
 {% set numpy = "1.19" %}  # [py<=39]
 {% set numpy = "1.21" %}  # [py>39]
 
@@ -10,10 +10,8 @@ package:
 # [python_impl == "pypy"]
 
 source:
-  # The sdist distributed by scipy contains pre-compiled pythran sources,
-  # as well as the boost-headers submodule (since 1.7.0).
   - url: https://github.com/scipy/scipy/archive/refs/tags/v{{ version }}.tar.gz
-    sha256: 1e59e624eb99aeb88cfddd0ccc6bc774ffe203820b98dd89d54b40bcb062f45d
+    sha256: 6ad2df96f141be7bf661461daf15c8d7d8032d77a0d772a52cb9feb236248eae
     patches:
       - patches/0002-arff-nodata-test-remove-endian-check.patch  # [s390x]
   # https://github.com/scipy/scipy/tree/v{{ version }}/scipy/_lib
@@ -53,10 +51,10 @@ requirements:
     - pkg-config    # [osx]
   host:
     - python
-    - cython >=0.29.21,<3.0
-    - pybind11 >=2.4.3,<2.10.0    
+    - cython >=0.29.32,<3.0
+    - pybind11 >=2.4.3,<2.11.0    
     - fftw  # [not (linux and s390x)]
-    - pythran >=0.11.0,<0.12.0
+    - pythran >=0.11.0,<0.13.0
     - setuptools <60
     - wheel <0.38.0
     - numpy {{ numpy }}
@@ -69,8 +67,8 @@ requirements:
     - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
   run:
     - python
-    # https://github.com/scipy/scipy/blob/v1.9.0/setup.py#L452
-    - numpy >={{ numpy }},<1.25.0
+    # https://github.com/scipy/scipy/blob/v1.9.3/setup.py#L452
+    - numpy >={{ numpy }},<1.26.0
     - {{ pin_compatible('fftw') }} # [not (linux and s390x)]
     - {{ pin_compatible('intel-openmp') }}  # [blas_impl == 'mkl']
 
@@ -84,9 +82,6 @@ requirements:
 # skip a test that fails with MKL + AVX512 (non-AVX512 passes) (See: https://github.com/scipy/scipy/issues/15533)
 {% set tests_to_skip = tests_to_skip + " or test_x0_equals_Mb[bicgstab]" %} # [blas_impl == 'mkl']
 
-# mark one linalg.solve_discrete_are as knownfail https://github.com/scipy/scipy/issues/16926
-{% set tests_to_skip = tests_to_skip + " or test_solve_discrete_are"  %} # [blas_impl == 'openblas']
-
 # skip failing s390x tests
 {% set tests_to_skip = tests_to_skip + " or test_jacobi_int" %} # [s390x] timeout after 1800s
 
@@ -94,9 +89,6 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_region4" %} # [win] tolerance mismatch (See open issue: https://github.com/scipy/scipy/issues/17123)
 
 # skip failing osx-64 tests
-{% set tests_to_skip = tests_to_skip + " or test_qz_single"           %} # [osx and x86_64] xfail in main. (See: https://github.com/scipy/scipy/issues/16949)
-{% set tests_to_skip = tests_to_skip + " or test_gges_tgexc[float32]" %} # [osx and x86_64] xfail in main. (See: https://github.com/scipy/scipy/issues/16949)
-{% set tests_to_skip = tests_to_skip + " or test_ppf_against_tables"  %} # [osx and x86_64] See open issue: https://github.com/scipy/scipy/issues/17124
 {% set tests_to_skip = tests_to_skip + " or test_bad_geneig"          %} # [osx and x86_64] See open issue: https://github.com/scipy/scipy/issues/17125
 
 test:


### PR DESCRIPTION
SciPy 1.9.3 is a bug-fix release with no new features compared to 1.9.1.
Release note: https://docs.scipy.org/doc/scipy/release.1.9.3.html
Repo: https://github.com/scipy/scipy/
Changes 1.9.1 1.9.3: https://github.com/scipy/scipy/compare/v1.9.1...v1.9.3

Configuration:
- https://github.com/scipy/scipy/blob/v1.9.3/pyproject.toml
- https://github.com/scipy/scipy/blob/v1.9.3/setup.py
- 
Changes:
- Update version to 1.9.3
- Update dependencies
- Remove skipped tests for issues that have been fixed.

We are still building with setuptools because the meson build is not stable yet.