### PR TITLE
Pin numpy version

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-channels:
-  mesters_org: scipy
-build_parameters:
-  - "--suppress-variables"
-  - "--error-overlinking"
-  - "--error-overdepending"

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,5 @@
-# the conda-build parameters to use for disabling --skip-existing
+channels:
+  mesters_org: scipy
 build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     folder: scipy/sparse/linalg/_propack/PROPACK
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<=37]
   missing_dso_whitelist:  # [linux and s390x]
     - $RPATH/ld64.so.1    # [linux and s390x] 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,6 @@ requirements:
     - python
     - cython 0.29.32
     - pybind11 2.10.1
-    - fftw 3.3.9  # [not (linux and s390x)]
     - pythran 0.12.1
     - setuptools <60
     - wheel <0.39.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set version = "1.10.0" %}
-{% set numpy = "1.19.5" %}  # [py<=39]
+{% set numpy = "1.19.5" %}  # [py<=39 and not (osx and arm64)]
+{% set numpy = "1.21" %}  # [py<=39 and (osx and arm64)]
 {% set numpy = "1.21" %}  # [py>39 and py<311]
 {% set numpy = "1.23" %}  # [py>=311]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -70,7 +70,6 @@ requirements:
     - python
     # https://github.com/scipy/scipy/blob/v1.10.0/setup.py#L452-L453
     - numpy >={{ numpy }},<1.27.0
-    - {{ pin_compatible('fftw') }} # [not (linux and s390x)]
     - {{ pin_compatible('intel-openmp') }}  # [blas_impl == 'mkl']
     # Needed for scipy.datasets
     - pooch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set version = "1.10.0" %}
-{% set numpy = "1.19" %}  # [py<=39]
+{% set numpy = "1.19.5" %}  # [py<=39]
 {% set numpy = "1.21" %}  # [py>39 and py<311]
 {% set numpy = "1.23" %}  # [py>=311]
 


### PR DESCRIPTION
The numpy version needs to be at least 1.19.5: https://github.com/scipy/scipy/blob/v1.10.0/pyproject.toml#L75-L79

For `osx-arm64`, the requirements are more ambiguous: https://github.com/scipy/scipy/blob/v1.10.0/pyproject.toml#L32-L35

`numpy 1.19.5` fails boost unit tests on that architecture, so I pinned them to `numpy 1.21`.

Jira ticket: https://anaconda.atlassian.net/jira/software/c/projects/PKG/issues/PKG-1218
Upstream: https://github.com/scipy/scipy/tree/v1.10.0