### PR TITLE
1.9.3 for 3.11

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,5 @@ build_parameters:
   - "--suppress-variables"
   - "--error-overlinking"
   - "--error-overdepending"
+
+aggregate_check: false

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -4,3 +4,9 @@ mkl:
 # openblas 0.3.21 has better osx-arm64 support than openblas 0.3.20
 openblas:
   - 0.3.21
+c_compiler_version:    # [osx and arm64]
+  - 12                 # [osx and arm64]
+cxx_compiler_version:  # [osx and arm64]
+  - 12                 # [osx and arm64]
+c_compiler:            # [win]
+  - vs2019             # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,7 @@
 {% set version = "1.9.3" %}
 {% set numpy = "1.19" %}  # [py<=39]
-{% set numpy = "1.21" %}  # [py>39]
+{% set numpy = "1.21" %}  # [py>39 and py<311]
+{% set numpy = "1.23" %}  # [py>=311]
 
 package:
   name: scipy
@@ -32,7 +33,7 @@ source:
     folder: scipy/sparse/linalg/_propack/PROPACK
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<=37]
   missing_dso_whitelist:  # [linux and s390x]
     - $RPATH/ld64.so.1    # [linux and s390x] 
@@ -51,10 +52,9 @@ requirements:
     - pkg-config    # [osx]
   host:
     - python
-    - cython >=0.29.32,<3.0
-    - pybind11 >=2.4.3,<2.11.0    
-    - fftw  # [not (linux and s390x)]
-    - pythran >=0.11.0,<0.13.0
+    - cython 0.29.32
+    - pybind11 2.10.1
+    - pythran 0.12.1
     - setuptools <60
     - wheel <0.38.0
     - numpy {{ numpy }}
@@ -69,7 +69,6 @@ requirements:
     - python
     # https://github.com/scipy/scipy/blob/v1.9.3/setup.py#L452
     - numpy >={{ numpy }},<1.26.0
-    - {{ pin_compatible('fftw') }} # [not (linux and s390x)]
     - {{ pin_compatible('intel-openmp') }}  # [blas_impl == 'mkl']
 
 # Scipy segfault when calling solver PROPACK _svdp at mkl_blas.cdotc (). see: https://github.com/scipy/scipy/issues/15108


### PR DESCRIPTION
Changes:
- Increase build number
- Adjust numpy pin for 3.11
- Pin host dependencies more explicitely
- Set compiler in cbc more explicitely
- Remove uneeded fftw dependency (same as done on 1.10).

Reason: pandas-profiling latest version needs scipy <1.10