### PR TITLE
1.9.3 build against mkl 2023

### DIFF
--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,6 +1,6 @@
-# mkl 2021 until dependencies get rebuild against 2022
+# mkl 2023
 mkl:
-  - 2021.*
+  - 2023.*
 # openblas 0.3.21 has better osx-arm64 support than openblas 0.3.20
 openblas:
   - 0.3.21

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -85,6 +85,7 @@ requirements:
 {% set tests_to_skip = tests_to_skip + " or test_solve_discrete_are"  %} # [blas_impl == 'openblas']
 
 # skip failing s390x tests
+{% set tests_to_skip = tests_to_skip + " or test_atol[bicg]" %} # [s390x] fails with numpy 1.24 https://github.com/scipy/scipy/issues/17839
 {% set tests_to_skip = tests_to_skip + " or test_jacobi_int" %} # [s390x] timeout after 1800s
 
 # skip failing win tests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,7 @@ source:
     folder: scipy/sparse/linalg/_propack/PROPACK
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<=37]
   missing_dso_whitelist:  # [linux and s390x]
     - $RPATH/ld64.so.1    # [linux and s390x] 


### PR DESCRIPTION
Changes:
- increase build number
- pin mkl to 2023
- skip a s390x test that fails with numpy 1.24.