### PR TITLE
update to 1.15.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,2 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
-
-channels:
-  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr97/11a1b6d

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
 build_env_vars:
   ANACONDA_ROCKET_ENABLE_PY313 : yes
+
+channels:
+  - https://staging.continuum.io/prefect/fs/numpy-feedstock/pr97/11a1b6d

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -30,8 +30,10 @@ if "%blas_impl%" == "openblas" (
 
 mkdir builddir
 REM Setting c++17. See: https://github.com/scipy/scipy/issues/19726
+REM Setting -j4 to limit parallelization in order to avoid random cython compilation issues.
 "%PYTHON%" -m build --wheel --no-isolation --skip-dependency-check ^
     -Cbuilddir=builddir ^
+    -Ccompile-args=-j4 ^
     -Csetup-args=-Dcpp_std=c++17 ^
     -Csetup-args=-Dblas=%BLAS% ^
     -Csetup-args=-Dlapack=%BLAS% ^

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,6 +9,7 @@ source:
     sha256: 033a75ddad1463970c96a88063a1df87ccfddd526437136b6ee81ff0312ebdf6
     patches:                                                     # [s390x]
       - patches/0002-arff-nodata-test-remove-endian-check.patch  # [s390x]
+      - patches/0003-do-not-check-dtype-in-test_compare_with_GCVSPL.patch # [s390x]
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.14.1" %}
+{% set version = "1.15.0" %}
 
 package:
   name: scipy
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/scipy/scipy/releases/download/v{{ version }}/scipy-{{ version }}.tar.gz
-    sha256: 5a275584e726026a5699459aa72f828a610821006228e841b94275c4a7c08417
+    sha256: 300742e2cc94e36a2880ebe464a1c8b4352a7b0f3e36ec3d2ac006cdbe0219ac
     patches:                                                     # [s390x]
       - patches/0002-arff-nodata-test-remove-endian-check.patch  # [s390x]
 
@@ -41,9 +41,9 @@ requirements:
   host:
     - python
     - cython >=3.0.8,<3.1.0
-    - pybind11 >=2.12.0,<2.13.0
-    - pythran >=0.14.0,<0.17.0
-    - meson-python >=0.15.0,<0.19.0
+    - pybind11 >=2.13.2,<2.14.0
+    - pythran >=0.14.0,<0.18.0
+    - meson-python >=0.15.0,<0.20.0
     - python-build
     - numpy 2.0 # [py<313]
     - numpy 2.1 # [py==313]
@@ -52,7 +52,7 @@ requirements:
     - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
   run:
     - python
-    - numpy >=1.23.5,<2.3
+    - numpy >=1.23.5,<2.5
 {% set tests_to_skip = "_not_a_real_test" %}
 
 # mark one linalg.solve_discrete_are as knownfail https://github.com/scipy/scipy/issues/16926
@@ -97,6 +97,7 @@ test:
     - scipy.cluster.vq
     - scipy.constants
     - scipy.datasets
+    - scipy.differentiate
     - scipy.fft
     - scipy.fftpack
     - scipy.integrate
@@ -115,6 +116,7 @@ test:
     - scipy.ndimage
     - scipy.odr
     - scipy.optimize
+    - scipy.optimize.elementwise
     - scipy.signal
     - scipy.signal.windows
     - scipy.sparse
@@ -140,7 +142,7 @@ test:
     - threadpoolctl
     - pooch
     - hypothesis >=6.30
-    - array-api-strict >=2.0
+    - array-api-strict >=2.0,<2.1.1
     # see comment above
     - intel-openmp {{ mkl }}  # [blas_impl == 'mkl']
     # output of numpy.show_config()
@@ -189,14 +191,13 @@ about:
     - scipy/io/_fast_matrix_market/LICENSE.txt
     - scipy/io/_fast_matrix_market/fast_matrix_market/dependencies/fast_float/LICENSE-MIT
     - scipy/io/_fast_matrix_market/fast_matrix_market/dependencies/ryu/LICENSE-Boost
-    - scipy/_lib/boost_math/LICENSE
     - scipy/_lib/_uarray/LICENSE
     - scipy/_lib/array_api_compat/LICENSE
+    - scipy/_lib/array_api_extra/LICENSE
+    - scipy/_lib/boost_math/LICENSE
+    - scipy/_lib/cobyqa/LICENSE
     - scipy/_lib/pocketfft/LICENSE.md
     - scipy/_lib/unuran/license.txt
-    - scipy/_lib/highs/LICENSE
-    - scipy/_lib/highs/extern/pdqsort/license.txt
-    - scipy/_lib/highs/extern/filereaderlp/LICENSE
     - scipy/fft/_pocketfft/LICENSE.md
     - scipy/sparse/linalg/_eigen/arpack/ARPACK/COPYING
     - scipy/sparse/linalg/_propack/PROPACK/license.txt

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -87,6 +87,10 @@ requirements:
 # see https://github.com/scipy/scipy/blob/v1.14.1/scipy/_lib/tests/test_import_cycles.py#L11
 {% set tests_to_skip = tests_to_skip + " or test_public_modules_importable" %}  # [win] 
 
+# test would pass with pytest 8 (verified with pytest 8.3.3)
+# see https://github.com/scipy/scipy/issues/22244
+{% set tests_to_skip = tests_to_skip + " or test_no_ZeroDivisionError" %}
+
 test:
   imports:
     - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.15.0" %}
+{% set version = "1.15.1" %}
 
 package:
   name: scipy
@@ -6,7 +6,7 @@ package:
 
 source:
   - url: https://github.com/scipy/scipy/releases/download/v{{ version }}/scipy-{{ version }}.tar.gz
-    sha256: 300742e2cc94e36a2880ebe464a1c8b4352a7b0f3e36ec3d2ac006cdbe0219ac
+    sha256: 033a75ddad1463970c96a88063a1df87ccfddd526437136b6ee81ff0312ebdf6
     patches:                                                     # [s390x]
       - patches/0002-arff-nodata-test-remove-endian-check.patch  # [s390x]
 

--- a/recipe/patches/0003-do-not-check-dtype-in-test_compare_with_GCVSPL.patch
+++ b/recipe/patches/0003-do-not-check-dtype-in-test_compare_with_GCVSPL.patch
@@ -1,0 +1,25 @@
+From ce7763451fb885bc303a32fbe36d6703ccdb689c Mon Sep 17 00:00:00 2001
+From: Charles Bousseau <cbousseau@anaconda.com>
+Date: Thu, 16 Jan 2025 16:23:43 -0500
+Subject: [PATCH] do not check dtype in test_compare_with_GCVSPL
+
+See: https://github.com/scipy/scipy/pull/22345
+---
+ scipy/interpolate/tests/test_bsplines.py | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/scipy/interpolate/tests/test_bsplines.py b/scipy/interpolate/tests/test_bsplines.py
+index 62c7365ee5e4..e8b1b2b58afc 100644
+--- a/scipy/interpolate/tests/test_bsplines.py
++++ b/scipy/interpolate/tests/test_bsplines.py
+@@ -2164,7 +2164,9 @@ def test_compare_with_GCVSPL(self):
+         # such tolerance is explained by the fact that the spline is built
+         # using an iterative algorithm for minimizing the GCV criteria. These
+         # algorithms may vary, so the tolerance should be rather low.
+-        xp_assert_close(y_compr, y_GCVSPL, atol=1e-4, rtol=1e-4)
++        # Not checking dtypes as gcvspl.npz stores little endian arrays, which
++        # result in conflicting dtypes on big endian systems. 
++        xp_assert_close(y_compr, y_GCVSPL, atol=1e-4, rtol=1e-4, check_dtype=False)
+ 
+     def test_non_regularized_case(self):
+         """


### PR DESCRIPTION
scipy 1.15.1

**Destination channel:** main

### Links

- PKG-6709
- https://github.com/scipy/scipy/tree/v1.15.1

Changes:
- limit parallelization on windows, for a more stable build.
- add patch on s390x for a test. https://github.com/scipy/scipy/pull/22345

