### PR TITLE
scipy 1.17.1 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "scipy" %}
-{% set version = "1.17.0" %}
+{% set version = "1.17.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   - url: https://github.com/{{ name }}/{{ name }}/releases/download/v{{ version }}/{{ name }}-{{ version }}.tar.gz
-    sha256: 2591060c8e648d8b96439e111ac41fd8342fdeff1876be2e19dea3fe8930454e
+    sha256: 95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0
 
 build:
   number: 0


### PR DESCRIPTION
scipy 1.17.1 

**Destination channel:** Defaults

### Links

- [PKG-12665]
- dev_url:        https://github.com/scipy/scipy/tree/v1.17.1
- conda_forge:    https://github.com/conda-forge/scipy-feedstock
- pypi:           https://pypi.org/project/scipy/1.17.1
- pypi inspector: https://inspector.pypi.io/project/scipy/1.17.1

### Explanation of changes:

- new version number


[PKG-12665]: https://anaconda.atlassian.net/browse/PKG-12665?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ