### PR TITLE
scipy 1.15: openblas on windows. 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr135/e496a4f
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr136/9aa4527
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr134/d228a66
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/da81b3f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+channels:
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr135/e496a4f
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr136/9aa4527
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr134/d228a66
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/da81b3f

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,6 +24,7 @@ set "SRC_DIR="
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
 if "%blas_impl%" == "openblas" (
     set "BLAS=openblas"
+    set "OPENBLAS_ROOT=%LIBRARY_PREFIX%"
 ) else (
     set "BLAS=mkl-sdl"
 )

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,3 +6,12 @@ MACOSX_SDK_VERSION:      # [osx]
   - 11.1                 # [osx]
 CONDA_BUILD_SYSROOT:     # [osx]
   - /Library/Developer/CommandLineTools/SDKs/MacOSX11.1.sdk  # [osx]
+
+blas_impl:
+  - mkl                    # [(x86 or x86_64) and not osx]
+  - openblas
+
+fortran_compiler:          # [win]
+  - flang                  # [win]
+fortran_compiler_version:  # [win]
+  - 20                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,12 +7,10 @@ package:
 source:
   - url: https://github.com/scipy/scipy/releases/download/v{{ version }}/scipy-{{ version }}.tar.gz
     sha256: eae3cf522bc7df64b42cad3925c876e1b0b6c35c1337c93e12c0f366f55b0eaf
-    patches:                                                     # [s390x]
-      - patches/0002-arff-nodata-test-remove-endian-check.patch  # [s390x]
 
 build:
-  number: 1
-  skip: true  # [py<310]
+  number: 2
+  skip: true  # [py<310 or py>313]
   missing_dso_whitelist:
     - $RPATH/ld64.so.1  # [linux and s390x]
     # sf_error_state is loaded with ctypes.WinDLL
@@ -33,11 +31,10 @@ requirements:
     - {{ stdlib('c') }}
     - {{ compiler('c') }}
     - {{ compiler('cxx') }}
+    - {{ compiler('fortran') }}
     # pythran code needs clang-cl on windows
     - clang   # [win]
     - lld     # [win]
-    - {{ compiler('fortran') }}
-    - patch # [s390x]
     - pkg-config
   host:
     - python
@@ -45,9 +42,10 @@ requirements:
     - pybind11 >=2.13.2,<2.14.0
     - pythran >=0.14.0,<0.18.0
     - meson-python >=0.15.0,<0.20.0
+    # meson-python: error: Could not find ninja version 1.8.2 or newer.
+    - ninja-base >=1.8.2
     - python-build
-    - numpy 2.0 # [py<313]
-    - numpy 2.1 # [py==313]
+    - numpy {{ numpy }}
     - pip
     - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
     - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']
@@ -82,6 +80,9 @@ requirements:
 # tolerance violation - related to https://github.com/scipy/scipy/issues/22022
 # might be due to openblas being updated
 {% set tests_to_skip = tests_to_skip + " or test_x0_working[tfqmr]" %}  # [linux and aarch64] 
+# float16 numerical differentiation tolerance failures - float16 precision (~3.3 decimal digits)
+# is insufficient for the derivative algorithm to converge within rtol=0.03125
+{% set tests_to_skip = tests_to_skip + " or (test_dtype and float16)" %}  # [linux and x86_64] 
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ requirements:
     - pybind11 >=2.13.2,<2.14.0
     - pythran >=0.14.0,<0.18.0
     - meson-python >=0.15.0,<0.20.0
-    # meson-python: error: Could not find ninja version 1.8.2 or newer.
+    # meson-python: error Could not find ninja version 1.8.2 or newer.
     - ninja-base >=1.8.2
     - python-build
     - numpy {{ numpy }}


### PR DESCRIPTION
scipy 1.15 rebuild 

**Destination channel:** defaults

### Links

- [PKG-13602](https://anaconda.atlassian.net/browse/PKG-13602) 

### Explanation of changes:

- Adds openblas output on windows
- Bump build number
- Limit to <314



[PKG-13602]: https://anaconda.atlassian.net/browse/PKG-13602?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ