### PR TITLE
scipy 1.17: openblas on windows.

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,5 @@
-build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY314 : yes
+channels:
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr135/e496a4f
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr136/9aa4527
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr134/d228a66
+  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/da81b3f

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-channels:
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr135/e496a4f
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr136/9aa4527
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr134/d228a66
-  - https://staging.continuum.io/pbp/fs/numpy-feedstock/pr133/da81b3f

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,6 +24,7 @@ set "SRC_DIR="
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
 if "%blas_impl%" == "openblas" (
     set "BLAS=openblas"
+    set "OPENBLAS_ROOT=%LIBRARY_PREFIX%"
 ) else (
     set "BLAS=mkl-sdl"
 )

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -6,18 +6,6 @@ cxx_compiler_version:      # [osx]
 mkl:
   - 2025.*
 
-numpy:
-  # python 3.10
-  - 2.4.4
-  # python 3.11
-  - 2.4.4
-  # python 3.12
-  - 2.4.4
-  # python 3.13
-  - 2.4.4
-  # python 3.14
-  - 2.4.4
-
 blas_impl:
   - mkl                    # [(x86 or x86_64) and not osx]
   - openblas

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -5,3 +5,24 @@ cxx_compiler_version:      # [osx]
 
 mkl:
   - 2025.*
+
+numpy:
+  # python 3.10
+  - 2.4.4
+  # python 3.11
+  - 2.4.4
+  # python 3.12
+  - 2.4.4
+  # python 3.13
+  - 2.4.4
+  # python 3.14
+  - 2.4.4
+
+blas_impl:
+  - mkl                    # [(x86 or x86_64) and not osx]
+  - openblas
+
+fortran_compiler:          # [win]
+  - flang                  # [win]
+fortran_compiler_version:  # [win]
+  - 20                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<311]
 
 requirements:


### PR DESCRIPTION
scipy 1.17 rebuild 

**Destination channel:** defaults

### Links

- [PKG-13573](https://anaconda.atlassian.net/browse/PKG-13573) 

### Explanation of changes:

- Adds openblas output on windows
- Bump build number



[PKG-13573]: https://anaconda.atlassian.net/browse/PKG-13573?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ