### PR TITLE
scipy 1.16: openblas on windows.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,6 +24,7 @@ set "SRC_DIR="
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
 if "%blas_impl%" == "openblas" (
     set "BLAS=openblas"
+    set "OPENBLAS_ROOT=%LIBRARY_PREFIX%"
 ) else (
     set "BLAS=mkl-sdl"
 )

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -3,5 +3,11 @@ c_compiler_version:        # [osx]
 cxx_compiler_version:      # [osx]
   - 17                     # [osx]
 
-mkl:
-  - 2025.*
+blas_impl:
+  - mkl                    # [(x86 or x86_64) and not osx]
+  - openblas
+
+fortran_compiler:          # [win]
+  - flang                  # [win]
+fortran_compiler_version:  # [win]
+  - 20                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 1
-  skip: true  # [py<311]
+  skip: true  # [py<311 or py>313]
 
 requirements:
   build:
@@ -63,6 +63,10 @@ requirements:
 # https://github.com/scipy/scipy/issues/22022
 # https://github.com/scipy/scipy/pull/22033
 {% set tests_to_skip = tests_to_skip + " or test_x0_working" %}  # [linux and aarch64]
+# float16 differentiation test tolerance failures — float16 precision is insufficient for the
+# derivative algorithm to converge within rtol=0.03125; test removed in 1.17 (PR #23282)
+# see https://github.com/scipy/scipy/issues/23248
+{% set tests_to_skip = tests_to_skip + " or (test_dtype and float16)" %}  # [linux and x86_64]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 01e87659402762f43bd2fee13370553a17ada367d42e7487800bf2916535aecb
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py<311]
 
 requirements:


### PR DESCRIPTION
scipy 1.16 rebuild 

**Destination channel:** defaults

### Links

- [PKG-13601](https://anaconda.atlassian.net/browse/PKG-13601) 

### Explanation of changes:

- Adds openblas output on windows
- Bump build number



[PKG-13601]: https://anaconda.atlassian.net/browse/PKG-13601?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ