### PR TITLE
 scipy 1.14: openblas on windows.

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -24,6 +24,7 @@ set "SRC_DIR="
 set "PKG_CONFIG_PATH=%LIBRARY_LIB%\pkgconfig;%LIBRARY_PREFIX%\share\pkgconfig;%BUILD_PREFIX%\Library\lib\pkgconfig"
 if "%blas_impl%" == "openblas" (
     set "BLAS=openblas"
+    set "OPENBLAS_ROOT=%LIBRARY_PREFIX%"
 ) else (
     set "BLAS=mkl-sdl"
 )

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -37,7 +37,8 @@ REM Setting c++17. See: https://github.com/scipy/scipy/issues/19726
     -Csetup-args=-Dblas=%BLAS% ^
     -Csetup-args=-Dlapack=%BLAS% ^
     -Csetup-args=-Duse-g77-abi=true ^
-    -Csetup-args=-Duse-pythran=true
+    -Csetup-args=-Duse-pythran=true ^
+    -Csetup-args=-Dfortran_std=none
 if errorlevel 1 (
   type builddir\meson-logs\meson-log.txt
   exit /b 1

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,8 @@
+blas_impl:
+  - mkl                    # [(x86 or x86_64) and not osx]
+  - openblas
+
+fortran_compiler:          # [win]
+  - flang                  # [win]
+fortran_compiler_version:  # [win]
+  - 20                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,8 @@ requirements:
     - pybind11 >=2.12.0,<2.13.0
     - pythran >=0.14.0,<0.17.0
     - meson-python >=0.15.0,<0.19.0
+    # meson-python: error: Could not find ninja version 1.8.2 or newer.
+    - ninja-base >=1.8.2
     - python-build
     - numpy {{ numpy }}
     - pip

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -95,6 +95,10 @@ requirements:
 # see https://github.com/scipy/scipy/blob/v1.14.1/scipy/_lib/tests/test_import_cycles.py#L11
 {% set tests_to_skip = tests_to_skip + " or test_public_modules_importable" %}  # [win] 
 
+# quadpack Fortran bug produces wrong complex weighted integration results
+# fixed in 1.15 via C rewrite (PR #21201); see https://github.com/scipy/scipy/issues/21057
+{% set tests_to_skip = tests_to_skip + " or (TestQuad and test_complex)" %}  # [osx]
+
 test:
   imports:
     - scipy

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -80,9 +80,16 @@ requirements:
 # see https://github.com/scipy/scipy/issues/15108
 {% set tests_to_skip = tests_to_skip + " or test_svd_linop or test_svdp or test_examples" %}  # [win] 
 
+# id_dist Fortran code produces wrong complex128 results under LLVM flang
+# fixed in 1.15 via Cython rewrite (PR #20558); see https://github.com/scipy/scipy/issues/9249
+{% set tests_to_skip = tests_to_skip + " or (TestInterpolativeDecomposition and complex128)" %}  # [win]
+
 # flaky test observerd on multiple platforms
 # see https://github.com/scipy/scipy/issues/18880
 {% set tests_to_skip = tests_to_skip + " or test_expm_multiply_dtype[True-float32-float32]" %}
+
+# tolerance violation in tfqmr solver - related to https://github.com/scipy/scipy/issues/22022
+{% set tests_to_skip = tests_to_skip + " or test_x0_working[tfqmr]" %}  # [linux and aarch64]
 
 # flaky test observerd on windows - time sensitive
 # see https://github.com/scipy/scipy/blob/v1.14.1/scipy/_lib/tests/test_import_cycles.py#L11

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -91,7 +91,7 @@ requirements:
 # tolerance violation in tfqmr solver - related to https://github.com/scipy/scipy/issues/22022
 {% set tests_to_skip = tests_to_skip + " or test_x0_working[tfqmr]" %}  # [linux and aarch64]
 
-# flaky test observerd on windows - time sensitive
+# flaky test observerd on windows - time sensitive 
 # see https://github.com/scipy/scipy/blob/v1.14.1/scipy/_lib/tests/test_import_cycles.py#L11
 {% set tests_to_skip = tests_to_skip + " or test_public_modules_importable" %}  # [win] 
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
       - patches/0002-arff-nodata-test-remove-endian-check.patch  # [s390x]
 
 build:
-  number: 0
-  skip: true  # [py<310]
+  number: 1
+  skip: true  # [py<310 or py>313]
   missing_dso_whitelist:
     - $RPATH/ld64.so.1  # [linux and s390x]
     # sf_error_state is loaded with ctypes.WinDLL
@@ -45,8 +45,7 @@ requirements:
     - pythran >=0.14.0,<0.17.0
     - meson-python >=0.15.0,<0.19.0
     - python-build
-    - numpy 2.0 # [py<313]
-    - numpy 2.1 # [py==313]
+    - numpy {{ numpy }}
     - pip
     - mkl-devel  {{ mkl }}  # [blas_impl == 'mkl']
     - openblas-devel {{ openblas }}  # [blas_impl == 'openblas']


### PR DESCRIPTION
scipy 1.14 rebuild 

**Destination channel:** defaults

### Links

- [PKG-13603)](https://anaconda.atlassian.net/browse/PKG-13603) 

### Explanation of changes:

- Adds openblas output on windows
- Bump build number
- Limit to <314
- pass fortran_std=none to meson. Sets the Fortran standard to "none", which effectively disables strict Fortran standard checking and receiving an invalid value of "Legacy"
