### PR TITLE
PKG-13552: scipy rebuild against pybind11 3.0.4

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+# Dev/staging channel for pre-release pybind11 3.0.4 (PKG-13552) — this
+# rebuild needs pybind11 3.0.4 + pybind11-abi 11 from staging so the
+# resulting scipy artifact pins pybind11-abi ==11 (not ==4/5). Remove
+# this `channels:` block once pybind11 3.0.4 ships to pkgs/main and the
+# pybind11-v3 migration is complete.
+channels:
+  - xkong-staging

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     sha256: 95d8e012d8cb8816c226aef832200b1d45109ed4464303e997c5b13122b297c0
 
 build:
-  number: 1
+  number: 2
   skip: true  # [py<311]
 
 requirements:


### PR DESCRIPTION
scipy 1.17.1

**DO NOT MERGE — staging only.** This PR uploads artifacts to `xkong-staging`
for use as a test/build dep by other PRs in the pybind11-v3 migration
(notably pytorch 2.12 PR #97).

### Links

- [PKG-13552](https://anaconda.atlassian.net/browse/PKG-13552)
- [Upstream repository](https://github.com/scipy/scipy)
- Relevant dependency PRs:
  - AnacondaRecipes/pybind11-feedstock#24 (pybind11 3.0.4 + abi 11 — staged)
  - AnacondaRecipes/pytorch-feedstock#97 (downstream consumer being unblocked)
  - AnacondaRecipes/optree-feedstock#6 (same pattern, already staged)

### Explanation of changes:

- **Build number 1 -> 2** (no source change). Same scipy 1.17.1, rebuilt
  against the new pybind11 ABI.
- **`abs.yaml` (new):** adds `channels: [xkong-staging]` so PBP resolves
  pybind11 3.0.4 + pybind11-abi 11 from staging instead of pybind11 2.13.x
  + abi 4/5 from pkgs/main. Comment in the file points to a cleanup TODO
  once pybind11 3.0.4 lands on pkgs/main.
- **Why:** scipy on pkgs/main is hot-fixed to pin `pybind11-abi ==4`
  (linux/osx) / `==5` (win-64) via repodata-hotfixes#316. pytorch 2.12
  pins `pybind11-abi ==11` (built against pybind11 3.0.4 from staging).
  pytorch tests pull scipy as a dep, and the two ABI pins are
  unsatisfiable in a single env solve. This rebuild produces a scipy
  artifact that pins `pybind11-abi ==11` via pybind11-abi's run_export,
  so pytorch's test env solves cleanly when pointed at xkong-staging.
- **No recipe change otherwise:** the existing host pin
  `pybind11 >=2.13.2,<3.1.0` already permits 3.0.4.
- **Artifact destination:** after PBP CI is green, all .conda outputs
  (linux-64, linux-aarch64, osx-arm64, win-64 × py311–py314) will be
  uploaded to `xkong-staging` (`--label main`). Not merged to AR master
  — this is a staging-only rebuild that will be replaced by the
  full pybind11-v3 migration PR once pybind11 3.0.4 ships to pkgs/main.

[PKG-13552]: https://anaconda.atlassian.net/browse/PKG-13552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ